### PR TITLE
perf: reuse *http.Client

### DIFF
--- a/scim/client.go
+++ b/scim/client.go
@@ -16,14 +16,12 @@ type (
 	Client struct {
 		endpoint       string
 		token          string
-		newHTTPClient  NewHTTPClient
+		httpClient     *http.Client
 		isError        IsError
 		parseResp      ParseResp
 		parseErrorResp ParseErrorResp
 	}
 
-	// NewHTTPClient returns a new http.Client .
-	NewHTTPClient func() (*http.Client, error)
 	// ParseResp parses a succeeded API response.
 	ParseResp func(resp *http.Response, output interface{}) error
 	// ParseErrorResp parses an API error response.
@@ -42,7 +40,7 @@ func NewClient(token string) *Client {
 	return &Client{
 		token:          token,
 		endpoint:       DefaultEndpoint,
-		newHTTPClient:  NewHTTPClientDefault,
+		httpClient:     http.DefaultClient,
 		isError:        IsErrorDefault,
 		parseResp:      ParseRespDefault,
 		parseErrorResp: ParseErrorRespDefault,
@@ -75,11 +73,7 @@ func (c *Client) getResp(
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.token))
 	req.Header.Add("Content-Type", "application/json")
 	req = req.WithContext(ctx)
-	client, err := c.newHTTPClient()
-	if err != nil {
-		return nil, err
-	}
-	return client.Do(req)
+	return c.httpClient.Do(req)
 }
 
 func (c *Client) parseResponse(

--- a/scim/set.go
+++ b/scim/set.go
@@ -1,13 +1,17 @@
 package scim
 
-// SetNewHTTPClient sets fn to c.
-// If fn is nil, NewHTTPClientDefault is used.
-func (c *Client) SetNewHTTPClient(fn NewHTTPClient) {
-	if fn == nil {
-		c.newHTTPClient = NewHTTPClientDefault
+import (
+	"net/http"
+)
+
+// SetHTTPClient sets the *http.Client to c.
+// If client is nil, http.DefaultClient is set.
+func (c *Client) SetHTTPClient(client *http.Client) {
+	if client == nil {
+		c.httpClient = http.DefaultClient
 		return
 	}
-	c.newHTTPClient = fn
+	c.httpClient = client
 }
 
 // SetParseResp sets fn to c.

--- a/scim/set_test.go
+++ b/scim/set_test.go
@@ -1,19 +1,25 @@
 package scim
 
 import (
+	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestClientSetNewHTTPClient(t *testing.T) {
+func TestClient_SetHTTPClient(t *testing.T) {
 	c := &Client{}
 
-	c.SetNewHTTPClient(nil)
-	require.NotNil(t, c.newHTTPClient)
+	c.SetHTTPClient(nil)
+	require.Equal(t, http.DefaultClient, c.httpClient)
 
-	c.SetNewHTTPClient(NewHTTPClientDefault)
-	require.NotNil(t, c.newHTTPClient)
+	c.SetHTTPClient(&http.Client{
+		Timeout: 10 * time.Second,
+	})
+	require.Equal(t, &http.Client{
+		Timeout: 10 * time.Second,
+	}, c.httpClient)
 }
 
 func TestClientSetParseResp(t *testing.T) {

--- a/scim/util.go
+++ b/scim/util.go
@@ -28,8 +28,3 @@ func ParseErrorRespDefault(resp *http.Response) error {
 	}
 	return a.Errors
 }
-
-// NewHTTPClientDefault is the default function for client to create new HTTP client internally.
-func NewHTTPClientDefault() (*http.Client, error) {
-	return &http.Client{}, nil
-}

--- a/scim/util_test.go
+++ b/scim/util_test.go
@@ -72,9 +72,3 @@ func TestParseErrorRespDefault(t *testing.T) {
 		require.Equal(t, d.exp, ParseErrorRespDefault(resp))
 	}
 }
-
-func TestNewHTTPClientDefault(t *testing.T) {
-	c, err := NewHTTPClientDefault()
-	require.NotNil(t, c)
-	require.Nil(t, err)
-}

--- a/scim/with.go
+++ b/scim/with.go
@@ -1,24 +1,28 @@
 package scim
 
+import (
+	"net/http"
+)
+
 func (c *Client) copy() *Client {
 	return &Client{
 		endpoint:       c.endpoint,
 		token:          c.token,
-		newHTTPClient:  c.newHTTPClient,
+		httpClient:     c.httpClient,
 		isError:        c.isError,
 		parseResp:      c.parseResp,
 		parseErrorResp: c.parseErrorResp,
 	}
 }
 
-// WithNewHTTPClient returns a shallow copy of c with its nweHTTPClient changed to fn.
-// If fn is nil, NewHTTPClientDefault is used.
-func (c *Client) WithNewHTTPClient(fn NewHTTPClient) *Client {
-	if fn == nil {
-		fn = NewHTTPClientDefault
-	}
+// WithHTTPClient returns a shallow copy of c with its httpClient changed to client.
+// If client is nil, http.DefaultClient is used.
+func (c *Client) WithHTTPClient(client *http.Client) *Client {
 	cl := c.copy()
-	cl.newHTTPClient = fn
+	if client == nil {
+		client = http.DefaultClient
+	}
+	cl.httpClient = client
 	return cl
 }
 

--- a/scim/with_test.go
+++ b/scim/with_test.go
@@ -1,7 +1,9 @@
 package scim
 
 import (
+	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -20,12 +22,19 @@ func TestClient_copy(t *testing.T) {
 	require.NotEqual(t, c2.token, c.token)
 }
 
-func TestClientWithNewHTTPClient(t *testing.T) {
+func TestClient_WithHTTPClient(t *testing.T) {
 	c := &Client{}
 
-	c2 := c.WithNewHTTPClient(nil)
-	require.Nil(t, c.newHTTPClient)
-	require.NotNil(t, c2.newHTTPClient)
+	c2 := c.WithHTTPClient(nil)
+	require.Nil(t, c.httpClient)
+	require.Equal(t, http.DefaultClient, c2.httpClient)
+	c3 := c.WithHTTPClient(&http.Client{
+		Timeout: 10 * time.Second,
+	})
+	require.Nil(t, c.httpClient)
+	require.Equal(t, &http.Client{
+		Timeout: 10 * time.Second,
+	}, c3.httpClient)
 }
 
 func TestClientWithParseResp(t *testing.T) {


### PR DESCRIPTION
https://golang.org/pkg/net/http/#Client

> The Client's Transport typically has internal state (cached TCP connections), so Clients should be reused instead of created as needed.
> Clients are safe for concurrent use by multiple goroutines.

BREAKING CHANGE: remove some interfaces, fields, and functions

* remove NewHTTPClient
* remove NewHTTPClientDefault
* replace Client's newHTTPClient to httpCient
* replace Client's SetNewHTTPClient to SetHTTPClient
* replace Client's WithNewHTTPClient to WithHTTPClient